### PR TITLE
Do not create loader if args.createLoader is false

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -53,6 +53,10 @@ if (args.includes('--loader')) {
   }
 }
 
+if (args.includes('--no-loader')) {
+  createLoader = false
+}
+
 const program = {
   dirname: __dirname,
   filename: __filename,
@@ -115,6 +119,7 @@ if (program.flags.includes('--compile')) {
     -n, --no-module                   compile without producing commonjs module
     -e, --electron                    compile for Electron
 
+    --no-loader                       do not create a loader file, conflicts with -l
     -l, --loader [ FILE | PATTERN ]   create a loader file and optionally define
                                       loader filename or pattern using % as filename replacer
                                       defaults to %.loader.js

--- a/index.ts
+++ b/index.ts
@@ -197,7 +197,7 @@ export const compileFile = async function (args: BytenodeOptions | string, outpu
     filename = args.filename
     compileAsModule = args.compileAsModule !== false
     electron = args.electron
-    createLoader = true
+    createLoader = args.createLoader
     loaderFilename = args.loaderFilename
     if (loaderFilename) createLoader = true
   }


### PR DESCRIPTION
createLoader is always true when calling compileFile with object as args. I wish it not to create a loader if args.createLoader is false.