### PR TITLE
fix: More robust method to find electron cli.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ const compileElectronCode = function (javascriptCode) {
   return new Promise((resolve, reject) => {
     let data = Buffer.from([]);
 
-    const electronPath = path.join('node_modules', 'electron', 'cli.js');
+    const electronPath = path.join(path.dirname(require.resolve('electron')), 'cli.js');
     if (!fs.existsSync(electronPath)) {
       throw new Error('Electron not installed');
     }


### PR DESCRIPTION
closes: https://github.com/bytenode/bytenode/issues/175