### PR TITLE
fix: update electron example

### DIFF
--- a/examples/electron-hello-world/main.js
+++ b/examples/electron-hello-world/main.js
@@ -9,7 +9,7 @@ v8.setFlagsFromString('--no-lazy');
 if (!fs.existsSync('./main-window.jsc')) {
   bytenode.compileFile({
     filename: './main-window.src.js',
-    output: ''./main-window.jsc',
+    output: './main-window.jsc',
     electron: true,
   });
 }

--- a/examples/electron-hello-world/main.js
+++ b/examples/electron-hello-world/main.js
@@ -7,8 +7,11 @@ const v8 = require('v8');
 v8.setFlagsFromString('--no-lazy');
 
 if (!fs.existsSync('./main-window.jsc')) {
-
-  bytenode.compileFile('./main-window.src.js', './main-window.jsc');
+  bytenode.compileFile({
+    filename: './main-window.src.js',
+    output: ''./main-window.jsc',
+    electron: true,
+  });
 }
 
 require('./main-window.jsc');

--- a/examples/electron-hello-world/package.json
+++ b/examples/electron-hello-world/package.json
@@ -7,6 +7,6 @@
     "start": "electron ."
   },
   "devDependencies": {
-    "electron": "^9.0.0"
+    "electron": "^30.0.0"
   }
 }


### PR DESCRIPTION
Electron example is missing ``electron: true``, AFAIK it is compiling using env's node and trying to decompile using Electron's.