### PR TITLE
feat: add electron-ipc example

### DIFF
--- a/examples/electron-ipc/README.md
+++ b/examples/electron-ipc/README.md
@@ -1,0 +1,18 @@
+# Introduction
+
+This example is Electron's [Inter-Process Communication (IPC)](https://www.electronjs.org/docs/latest/tutorial/ipc)
+in action. It uses a preload script to expose the APIs to de renderer, from the renderer we call the API
+by using the `window` object (e.g `window.encodeMessage`). In the main process we handle the call and return.
+
+Using IPC with preload, all the node code stay in the main process (which will be compiled), and renderer will have only front-end code.
+Also it is not necessary to use nodeIntegration, or any other insecure flag.
+
+Preload script is not compiled since it's only a bridge between renderer and main process.
+
+## How to run this example?
+
+```bash
+npm install
+npm run dev # this will run `main.js` (src script)
+npm start # this will compile `main.js` to `main.jsc` and run the compiled script
+```

--- a/examples/electron-ipc/compile.js
+++ b/examples/electron-ipc/compile.js
@@ -1,0 +1,12 @@
+"use strict";
+
+const bytenode = require("../../"); // require('bytenode');
+const v8 = require("v8");
+
+v8.setFlagsFromString("--no-lazy");
+
+bytenode.compileFile({
+  filename: "./main.js",
+  electron: true,
+  electronPath: require("electron"),
+});

--- a/examples/electron-ipc/index.html
+++ b/examples/electron-ipc/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Hello World!</title>
+  </head>
+
+  <body>
+    <input id="message" type="text" value="Message to be encoded." /><br />
+    <button id="encode">Encode message</button> <br /><br />
+    <span id="result"></span>
+
+    <script>
+      document.getElementById("encode").addEventListener("click", async () => {
+        const message = document.getElementById("message").value;
+        console.log("From renderer:", message);
+
+        // `window.encodeMessage` is defined in `preload.js`, and handled in `main.js`
+        const response = await window.encodeMessage(message);
+        console.log("From main process:", response);
+        document.getElementById("result").innerText = "Encoded: " + response;
+      });
+    </script>
+  </body>
+</html>

--- a/examples/electron-ipc/main.js
+++ b/examples/electron-ipc/main.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const { app, BrowserWindow, ipcMain } = require("electron");
+const path = require("path");
+const crypto = require("crypto");
+
+const createWindow = () => {
+  const mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, "index.html"));
+  mainWindow.webContents.openDevTools();
+};
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on("ready", createWindow);
+
+// Quit when all windows are closed, except on macOS. There, it's common
+// for applications and their menu bar to stay active until the user quits
+// explicitly with Cmd + Q.
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") {
+    app.quit();
+  }
+});
+
+app.on("activate", () => {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  }
+});
+
+// This is handling the `encode-message` IPC event
+ipcMain.handle("encode-message", (event, ...args) =>
+  crypto
+    .createHash("sha256")
+    .update(...args)
+    .digest("hex")
+);

--- a/examples/electron-ipc/main.loader.js
+++ b/examples/electron-ipc/main.loader.js
@@ -1,0 +1,3 @@
+require("../../"); // require('bytenode');
+
+require("./main.jsc");

--- a/examples/electron-ipc/package.json
+++ b/examples/electron-ipc/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "electron-ipc",
+  "version": "0.0.1",
+  "private": true,
+  "main": "main.loader.js",
+  "scripts": {
+    "start": "node compile.js && electron .",
+    "dev": "electron main.js"
+  },
+  "devDependencies": {
+    "electron": "^30.0.0"
+  }
+}

--- a/examples/electron-ipc/preload.js
+++ b/examples/electron-ipc/preload.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const { contextBridge, ipcRenderer } = require("electron");
+
+// This is exposing 'encodeMessage' to renderer process,
+// it can be called in renderer process by `window.encodeMessage`
+contextBridge.exposeInMainWorld("encodeMessage", (...args) =>
+  ipcRenderer.invoke("encode-message", ...args)
+);


### PR DESCRIPTION
Added a new Electron example, using [Inter-Process Communication](https://www.electronjs.org/docs/latest/tutorial/ipc) and [preload script](https://www.electronjs.org/docs/latest/tutorial/tutorial-preload).

The example don't use `nodeIntegration` or any other insecure flag.

I think that separating the compile script from the loader (thus using `electron: true`) makes it more on par with the docs (and real projects).