### PR TITLE
fix: surface real electronMain compile errors + add electronMain test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,9 @@ jobs:
             npm-${{ runner.os }}-${{ matrix.node-version }}-
       - name: Install Packages
         run: npm install
+      # The electronMain tests launch a real Electron browser process, which
+      # needs a display on Linux. Provide a virtual one via Xvfb.
+      - name: Install Xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
       - name: Run Tests
-        run: npm test
+        run: xvfb-run --auto-servernum npm test

--- a/lib/index.js
+++ b/lib/index.js
@@ -276,12 +276,14 @@ const compileElectronMainCode = function (javascriptCode, options) {
       '    const script = new vm.Script(code, { produceCachedData: true });',
       '    const buf = (script.createCachedData && script.createCachedData.call) ? script.createCachedData() : script.cachedData;',
       '    fs.writeFileSync(' + JSON.stringify(outFile) + ', buf);',
-      '    process.exitCode = 0;',
+      // Use app.exit(code) rather than `process.exitCode = code; app.quit()`:
+      // app.quit() runs the graceful-shutdown path and does NOT propagate
+      // process.exitCode, so a failed compile would otherwise exit 0 and the
+      // parent would misreport the real error as a missing-output-file ENOENT.
+      '    app.exit(0);',
       '  } catch (err) {',
       '    process.stderr.write(String((err && err.stack) || err) + "\\n");',
-      '    process.exitCode = 1;',
-      '  } finally {',
-      '    app.quit();',
+      '    app.exit(1);',
       '  }',
       '}',
       'app.whenReady().then(run);'
@@ -293,18 +295,55 @@ const compileElectronMainCode = function (javascriptCode, options) {
       try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
     };
 
-    const child = spawn(electronPath, [compilerScript], {
+    // Pass --no-sandbox on argv (not only via app.commandLine.appendSwitch in the
+    // compiler script): the SUID/zygote sandbox initializes before the script runs,
+    // so an in-script switch is too late and Electron aborts as root / in CI
+    // containers. It must come BEFORE the script path so Electron treats it as a
+    // switch rather than an argument to the app. No window is created here, so
+    // disabling the sandbox is safe.
+    const child = spawn(electronPath, ['--no-sandbox', compilerScript], {
       // Deliberately NOT setting ELECTRON_RUN_AS_NODE: we want the browser/main process.
       env: process.env,
-      stdio: ['ignore', 'inherit', 'inherit']
+      // Capture (don't inherit) the child's streams. A real Electron browser
+      // process prints benign startup noise (GPU/Vulkan/deprecation warnings) to
+      // stderr; inheriting it pollutes the caller's output and makes a genuine
+      // compile error indistinguishable from chatter. We buffer both streams and
+      // surface them only when they matter: folded into the rejection on failure,
+      // or printed when BYTENODE_DEBUG is set.
+      stdio: ['ignore', 'pipe', 'pipe']
     });
+
+    let stdout = '';
+    let stderr = '';
+    if (child.stdout) {
+      child.stdout.setEncoding('utf8');
+      child.stdout.on('data', (chunk) => { stdout += chunk; });
+    }
+    if (child.stderr) {
+      child.stderr.setEncoding('utf8');
+      child.stderr.on('data', (chunk) => { stderr += chunk; });
+    }
 
     child.on('error', (err) => { cleanup(); reject(err); });
 
-    child.on('exit', (code) => {
+    // Use 'close' (not 'exit'): 'exit' can fire before the stdout/stderr pipes
+    // have fully drained, which would let us reject with a truncated/empty error
+    // detail. 'close' fires only after all stdio streams have ended.
+    child.on('close', (code, signal) => {
+      if (DEBUG && (stdout || stderr)) {
+        console.error('[bytenode] electronMain stdout:\n' + stdout);
+        console.error('[bytenode] electronMain stderr:\n' + stderr);
+      }
       if (code !== 0) {
         cleanup();
-        reject(new Error('Electron main-process bytecode compilation failed (exit code ' + code + ')'));
+        const detail = stderr.trim() || stdout.trim();
+        // On a signal kill (e.g. a sandbox abort) code is null; report the signal
+        // so the failure isn't a misleading "exit code null".
+        const how = signal ? 'signal ' + signal : 'exit code ' + code;
+        reject(new Error(
+          'Electron main-process bytecode compilation failed (' + how + ')' +
+          (detail ? ':\n' + detail : '')
+        ));
         return;
       }
       try {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -240,6 +240,107 @@ describe('Bytenode', () => {
       }
     });
   });
+
+  describe('compileFile() for Electron main process (electronMain)', () => {
+    // `electronMain` compiles inside a real Electron *browser* process, which is
+    // slow to boot — give each case room. On headless Linux CI the process needs
+    // a virtual display (the workflow wraps the run in xvfb).
+    const tempPath = path.join(__dirname, TEMP_DIR + '-electron-main');
+    const testFilePath = path.join(__dirname, TEST_FILE);
+    const outputFile = path.join(tempPath, TEST_FILE.replace('.js', '.jsc'));
+    const loaderFile = path.join(tempPath, TEST_FILE);
+
+    before(async function () {
+      this.timeout(120000);
+      if (!fs.existsSync(tempPath)) {
+        fs.mkdirSync(tempPath);
+      }
+      await bytenode.compileFile({
+        filename: testFilePath,
+        output: outputFile,
+        loaderFilename: '%.js',
+        electronMain: true
+      });
+    });
+
+    it('creates non-zero length binary and loader files', () => {
+      const jscStats = fs.statSync(outputFile);
+      assert.ok(jscStats.isFile(), ".jsc File Doesn't Exist");
+      assert.ok(jscStats.size, 'Zero Length .jsc File');
+      const loaderStats = fs.statSync(loaderFile);
+      assert.ok(loaderStats.isFile(), "Loader File Doesn't Exist");
+      assert.ok(loaderStats.size, 'Zero Length Loader File');
+    });
+
+    it('produces bytecode that loads in a real Electron main process', async function () {
+      this.timeout(120000);
+      // The whole point of electronMain: the .jsc must load in the browser/main
+      // process (where ELECTRON_RUN_AS_NODE bytecode would be rejected on V8 >=
+      // 14.8). Launch Electron normally (NOT run-as-node) and require the bytecode.
+      const runnerPath = path.join(tempPath, 'runner.js');
+      const repoLib = path.resolve(__dirname, '..', 'lib', 'index.js');
+      const runnerSrc = [
+        "const { app } = require('electron');",
+        'if (typeof app.disableHardwareAcceleration === "function") app.disableHardwareAcceleration();',
+        "if (app.commandLine && app.commandLine.appendSwitch) app.commandLine.appendSwitch('no-sandbox');",
+        // Register bytenode's .jsc require hook, then load the bytecode directly.
+        // (The generated loader uses require('bytenode'), which can't resolve
+        // inside a checkout of bytenode itself.)
+        'require(' + JSON.stringify(repoLib) + ');',
+        'app.whenReady().then(() => {',
+        '  try {',
+        '    const value = require(' + JSON.stringify(outputFile) + ');',
+        '    process.stdout.write("LOADED:" + String(value));',
+        '    app.exit(0);',
+        '  } catch (err) {',
+        '    process.stderr.write(String((err && err.stack) || err));',
+        '    app.exit(1);',
+        '  }',
+        '});'
+      ].join('\n');
+      fs.writeFileSync(runnerPath, runnerSrc);
+
+      await assert.doesNotReject(() => {
+        return new Promise((resolve, reject) => {
+          // --no-sandbox on argv: same reason as the compiler in lib/index.js —
+          // the SUID sandbox initializes before the script can disable it.
+          const proc = spawn(electronPath, [runnerPath, '--no-sandbox']); // browser process
+          let out = '';
+          let err = '';
+          proc.stdout.on('data', (d) => { out += d; });
+          proc.stderr.on('data', (d) => { err += d; });
+          proc.on('error', reject);
+          proc.on('exit', (code) => {
+            if (code === 0 && out.includes('LOADED:42')) resolve();
+            else reject(new Error('Loader failed (code ' + code + '): ' + (err || out)));
+          });
+        });
+      }, 'electronMain .jsc failed to load in an Electron main process');
+    });
+
+    it('rejects with the underlying error when compilation fails', async function () {
+      this.timeout(120000);
+      const badFile = path.join(tempPath, 'bad-input.js');
+      fs.writeFileSync(badFile, 'const x = ;'); // guaranteed SyntaxError
+      await assert.rejects(
+        () => bytenode.compileFile({
+          filename: badFile,
+          output: path.join(tempPath, 'bad.jsc'),
+          electronMain: true
+        }),
+        // The real compile error must be surfaced to the caller, not swallowed
+        // behind a generic "exit code 1". (Regression guard for the error contract.)
+        (e) => /SyntaxError/.test(e.message),
+        'expected the underlying SyntaxError to surface in the rejection'
+      );
+    });
+
+    after(() => {
+      if (fs.existsSync(tempPath)) {
+        rimraf(tempPath);
+      }
+    });
+  });
 });
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -302,15 +302,18 @@ describe('Bytenode', () => {
 
       await assert.doesNotReject(() => {
         return new Promise((resolve, reject) => {
-          // --no-sandbox on argv: same reason as the compiler in lib/index.js —
-          // the SUID sandbox initializes before the script can disable it.
-          const proc = spawn(electronPath, [runnerPath, '--no-sandbox']); // browser process
+          // --no-sandbox before the script path: same reason as the compiler in
+          // lib/index.js — the SUID sandbox initializes before the script can
+          // disable it, and a switch after the path is treated as an app argument.
+          const proc = spawn(electronPath, ['--no-sandbox', runnerPath]); // browser process
           let out = '';
           let err = '';
           proc.stdout.on('data', (d) => { out += d; });
           proc.stderr.on('data', (d) => { err += d; });
           proc.on('error', reject);
-          proc.on('exit', (code) => {
+          // 'close' (not 'exit') so stdout/stderr are fully drained before we
+          // assert on `out` — matches the production code and avoids truncation.
+          proc.on('close', (code) => {
             if (code === 0 && out.includes('LOADED:42')) resolve();
             else reject(new Error('Loader failed (code ' + code + '): ' + (err || out)));
           });


### PR DESCRIPTION
## What & why

`compileFile({ electronMain: true })` / `compileElectronMainCode` (added in 1.6.0) compiles bytecode inside a real Electron **main** process — required on Electron ≥ 42 (V8 ≥ 14.8), where the browser snapshot diverges from the Node snapshot used by `ELECTRON_RUN_AS_NODE`.

It had no test coverage, and adding some surfaced three failure modes:

1. **Unreliable exit code (#263).** The compiler script signalled failure with `process.exitCode = 1; app.quit()`, but `app.quit()` does **not** honor `process.exitCode` — so a failed compile exited **0**. The parent then tried to read a `.jsc` that was never written and rejected with a misleading `ENOENT: … output.jsc`, throwing away the real error.
2. **Lost error detail (#263).** `stdio: ['ignore','inherit','inherit']` dumped benign Electron browser-startup noise straight to the caller and gave no structured way to obtain the actual compile error.
3. **Sandbox abort as root / in CI.** The compiler tries to disable the sandbox with an in-script `app.commandLine.appendSwitch('no-sandbox')`, but that runs too late — the SUID/zygote sandbox initializes before the script does, so Electron aborts (`The SUID sandbox helper binary … is not configured correctly`). The flag has to be on argv.

### Before / after (#263)

A source file with a syntax error, compiled via `electronMain`:

**Before**
```
Error: ENOENT: no such file or directory, open '/…/bytenode-electron-main-XXXX/output.jsc'
```

**After**
```
Electron main-process bytecode compilation failed (exit code 1):
evalmachine.<anonymous>:1
(function (exports, require, module, __filename, __dirname) { const x = ;
                                                                        ^
SyntaxError: Unexpected token ';'
```

## Changes

- **`app.exit(code)`** in the compiler script, so the exit code is reliable.
- **Capture** the child's stdout/stderr instead of inheriting them, and fold the detail into the rejected `Error` on failure. Silent on success unless `BYTENODE_DEBUG` is set. Streams are read on `'close'` (not `'exit'`) so the detail can't be truncated by an undrained pipe.
- **`--no-sandbox` on argv** for the compiler process, so it doesn't abort when Electron runs as root / in CI containers. (No window is created, so disabling the sandbox is safe — this matches the intent of the existing in-script switch, which never actually took effect.)
- **First tests for `electronMain`**: artifact creation, a round-trip load of the `.jsc` in a real Electron main process (where `ELECTRON_RUN_AS_NODE` bytecode would be rejected on V8 ≥ 14.8), and a regression test asserting the underlying error surfaces.
- **Xvfb in CI** — these are the first tests that launch an Electron browser process, which needs a display on Linux.

## Testing

- Full suite green on **Electron 41.8.0 and 42.4.1**, multiple runs.
- With the `lib/index.js` change reverted, the new error-contract test **fails** — confirming it's a genuine regression guard rather than a tautology.

Closes #263
